### PR TITLE
Orthographic camera mode was only repaired for URP 8 --Now works both in 8.2 and 11

### DIFF
--- a/URP_NiloCatExtension_ScreenSpaceDecal_Unlit.shader
+++ b/URP_NiloCatExtension_ScreenSpaceDecal_Unlit.shader
@@ -205,7 +205,7 @@ Shader "Universal Render Pipeline/NiloCat Extension/Screen Space Decal/Unlit"
                     //----------------------------------------------------------------------------
 				    float2 viewRayEndPosVS_xy = float2(unity_OrthoParams.xy * (i.screenPos.xy - 0.5) * 2 /* to clip space */);  // Ortho near/far plane xy pos 
 				    float4 vposOrtho = float4(viewRayEndPosVS_xy, -sceneDepthVS, 1);                                            // Constructing a view space pos
-				    float3 wposOrtho = mul(unity_CameraToWorld, vposOrtho).xyz;                                                 // Trans. view space to world space
+				    float3 wposOrtho = mul(UNITY_MATRIX_I_V, vposOrtho).xyz;                                                 // Trans. view space to world space
                     //----------------------------------------------------------------------------
 
                     // transform world to object space(decal space)


### PR DESCRIPTION
unity_CameraToWorld no longer works the same in URP 11.0 as it worked in URP 8. I used the original UNITY_MATRIX_I_V matrix (from an old version of this repo.) with the LUX code. Hoping I won't have to fix anything again.

More on this here:
https://forum.unity.com/threads/where-is-unity_cameratoworld-documented.908183/
